### PR TITLE
Feat(Logger)

### DIFF
--- a/src/server/config/colorLevel.js
+++ b/src/server/config/colorLevel.js
@@ -1,0 +1,7 @@
+module.exports = {
+  error: 'red',
+  warn: 'yellow',
+  info: 'green',
+  http: 'magenta',
+  debug: 'white',
+}

--- a/src/server/config/levelLog.js
+++ b/src/server/config/levelLog.js
@@ -1,0 +1,8 @@
+module.exports = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  http: 3,
+  verbose: 4,
+  debug: 5,
+}

--- a/src/server/middlewares/morgan.middleware.js
+++ b/src/server/middlewares/morgan.middleware.js
@@ -1,0 +1,13 @@
+const morgan = require('morgan');
+const logger = require('../utils/logger');
+
+const stream = {
+  write: (message) => logger.http(message),
+};
+
+const skip = () => {
+  const env = process.env.NODE_ENV || 'development';
+  return env != 'development';
+}
+
+module.exports = morgan('combined', { stream, skip });

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -10,10 +10,11 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 const passport = require('passport');
 const MONGO_URL = require('./config/db.js');
-const morgan = require('morgan');
+const morgan = require('./middlewares/morgan.middleware');
 const { default: helmet } = require('helmet');
 const routes = require('./routes/index.js');
 const app = express();
+const logger = require('./utils/logger');
 
 app.all('/*', function (req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
@@ -31,7 +32,7 @@ app.use(session({
   resave: false,
   saveUninitialized: true
 }));
-app.use(morgan('combined'));
+app.use(morgan);
 app.use(
   helmet({
     crossOriginEmbedderPolicy: false,
@@ -103,6 +104,7 @@ app.get('/logout', function (req, res) {
 
 app.get('/dashboard', (req, res) => {
   // Check if the user is authenticated
+  logger.error('Error unico');
   if (!req.user) {
     // If not, redirect to the login page
     res.redirect('/login');
@@ -188,5 +190,5 @@ app.use('*', (req, res) => {
 
 // Listen on port 3000 or the next available port
 const server = app.listen(3000, () => {
-  console.log(`Server is listening on port: ${server.address().port}`);
+  logger.info(`Server is listening on port: ${server.address().port}`);
 });

--- a/src/server/utils/logger.js
+++ b/src/server/utils/logger.js
@@ -1,0 +1,35 @@
+const winston = require('winston');
+const levels = require('../config/levelLog');
+const colors = require('../config/colorLevel');
+
+ const level = () => {
+   const env = process.env.NODE_ENV || 'development';
+   const isDevelopment = env === 'development';
+
+   return isDevelopment ? 'debug' : 'warn';
+ }
+
+winston.addColors(colors);
+
+const format = winston.format.combine(
+  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms'}),
+  winston.format.colorize({ all: true }),
+  winston.format.printf((info) => `${info.timestamp} ${info.level}: ${info.message}`
+  ),
+);
+
+const transports = [
+  new winston.transports.Console(),
+  new winston.transports.File({
+    filename: 'logs/error.log',
+    level: 'error'
+  }),
+  new winston.transports.File({filename: 'logs/all.log'})
+];
+
+module.exports = winston.createLogger({
+  level: level(),
+  levels,
+  format,
+  transports,
+});


### PR DESCRIPTION
### Details
- Create modulo for config winston
- Config winston log file. Currently there are two log files(error and all). If you consider it necessary to define up to what level of error will work and leave only one log file. 
- To use winston as a replacement for console.log, call the logger(src/server/utils/logger) module and specify the log level.`logger.info('text')`
- Config and custom módule for morgan middleware